### PR TITLE
Changed: Test workflow to use local action for self-testing

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -4,15 +4,8 @@ on:
   schedule:
     - cron: "0 4 * * *" # Run daily at 4am
   workflow_dispatch:
-  push:
-    tags:
-      - "v1"
-      - "v1-test"
-    paths:
-      - "action.yml"
-      - ".github/workflows/test-build-workflow.yml"
   pull_request:
-    branches: [master]
+    branches: [v1-master]
     paths:
       - "action.yml"
       - ".github/workflows/test-build-workflow.yml"
@@ -60,14 +53,18 @@ jobs:
             label: "[Wine] i686-pc-windows-gnu"
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Coverage Build
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           rust-toolchain: stable
           target: ${{ matrix.target }}
           use-cross: ${{ matrix.use-cross }}
@@ -78,14 +75,18 @@ jobs:
   test-nightly:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Nightly Build
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           rust-toolchain: nightly
           target: x86_64-unknown-linux-gnu
           features: "c-exports,std"
@@ -95,14 +96,18 @@ jobs:
   test-beta:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Beta Build
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           rust-toolchain: beta
           target: x86_64-unknown-linux-gnu
           features: "c-exports,std"
@@ -112,14 +117,18 @@ jobs:
   test-specific-nightly:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Specific Nightly Release
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           rust-toolchain: nightly-2025-09-18
           target: x86_64-unknown-linux-gnu
           features: "c-exports,std"
@@ -129,14 +138,18 @@ jobs:
   test-specific-version:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Specific Version
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           rust-toolchain: 1.90.0
           target: x86_64-unknown-linux-gnu
           features: "c-exports,std"
@@ -158,19 +171,23 @@ jobs:
             target: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust-toolchain }}
           target: ${{ matrix.target }}
       - name: Test Skipping Rust Install
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           rust-toolchain: ${{ matrix.rust-toolchain }}
           target: ${{ matrix.target }}
           install-rust-toolchain: false
@@ -179,27 +196,35 @@ jobs:
   test-skipping-rust-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Skipping Rust Cache
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           setup-rust-cache: false
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   test-skipping-coverage-upload:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v6
       - name: Checkout Test Repository
         uses: actions/checkout@v6
         with:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
+          path: test-project
       - name: Test Skipping Coverage Upload
-        uses: Reloaded-Project/devops-rust-test-and-coverage@v1-test
+        uses: ./
         with:
+          rust-project-path: test-project
           upload-coverage: false
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -61,6 +61,9 @@ jobs:
           repository: Sewer56/prs-rs
           ref: 149060527e685360687d7332742ac016b39af8a7
           path: test-project
+      - name: Remove test project rust-toolchain override
+        shell: bash
+        run: rm -f test-project/rust-toolchain.toml test-project/rust-toolchain
       - name: Test Coverage Build
         uses: ./
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -8,7 +8,7 @@ on:
     branches: [v1-master]
     paths:
       - "action.yml"
-      - ".github/workflows/test-build-workflow.yml"
+      - ".github/workflows/test-workflow.yml"
 
 jobs:
   test-coverage-build:


### PR DESCRIPTION
- Restructured checkout order: action repository first, then test repository to test-project/ subdirectory
- Updated action reference from remote @v1-test tag to local path (./)
- Added rust-project-path parameter to all 8 job invocations
- Changed pull_request branch target from master to v1-master
- Removed push.tags trigger section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to trigger on branches rather than tags and adjusted workflow references.
  * Replaced external test action with a local testing action across all test jobs.
  * Ensured repository checkout happens earlier and added a dedicated checkout for test code plus a cleanup step for toolchain overrides.
  * Added project-path input to testing jobs and preserved existing toolchain/feature configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->