### PR TITLE
Remove Wine testing from test workflow

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -43,14 +43,6 @@ jobs:
           - os: macos-latest # M1/M2 (aarch64)
             target: aarch64-apple-darwin
             use-cross: false
-          - os: ubuntu-latest
-            target: x86_64-pc-windows-gnu
-            use-cross: true
-            label: "[Wine] x86_64-pc-windows-gnu"
-          - os: ubuntu-latest
-            target: i686-pc-windows-gnu
-            use-cross: true
-            label: "[Wine] i686-pc-windows-gnu"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Action Repository


### PR DESCRIPTION
## Summary
- Remove Wine-based Windows GNU testing (x86_64-pc-windows-gnu and i686-pc-windows-gnu) from the test workflow matrix