### PR TITLE
Fixed: Pass GITHUB_TOKEN to cargo-binstall for higher rate limits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -196,10 +196,14 @@ runs:
     - name: Install cargo-binstall
       if: inputs.install-binstall == 'true'
       uses: cargo-bins/cargo-binstall@main
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Install Tarpaulin (via binstall)
       if: inputs.use-cross == 'false' && inputs.use-tarpaulin == 'true' && inputs.use-binstall == 'true'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         # The force here is kinda forced for back compat reasons, else cargo might not pick up the binary;
         # while binstall thinks it's there due to caching. Current versions wouldn't cache preinstalled cargo-tarpaulin


### PR DESCRIPTION
## Summary

Passes `GITHUB_TOKEN` to cargo-binstall to avoid GitHub API rate limiting.

## Problem

When cargo-binstall installs packages from GitHub releases, it queries the GitHub API. Without authentication, this is limited to **60 requests/hour**, causing `403 Forbidden` errors in CI environments. This leads to:
- Timeout errors: `deadline has elapsed`
- Fallback to `cargo install` (compiles from source, adding ~5-10 min per job)

## Solution

Pass `GITHUB_TOKEN` via environment variable to both:
1. The `cargo-bins/cargo-binstall@main` action (line 198-199)
2. The `cargo binstall cargo-tarpaulin` command (line 203-204)

This gives:
- **1000 requests/hour** rate limit (vs 60 unauthenticated)
- Reliable binary downloads from GitHub releases
- Faster CI (no source compilation fallback)

## References

- [cargo-binstall issue #2045](https://github.com/cargo-bins/cargo-binstall/issues/2045) - Same 403 error
- [hickory-dns PR #2770](https://github.com/hickory-dns/hickory-dns/pull/2770) - Same fix applied
- [GitHub docs: github.token context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context)